### PR TITLE
Fix minor bugs

### DIFF
--- a/dpr_scale/conf/trainer/gpu_1_host.yaml
+++ b/dpr_scale/conf/trainer/gpu_1_host.yaml
@@ -1,6 +1,6 @@
 # @package _group_
 gpus: 8
-max_steps: 500
+max_steps: null
 max_epochs: 40
 num_nodes: 1
 num_sanity_val_steps: 0

--- a/dragon/data_prep/prep_beir_eval.py
+++ b/dragon/data_prep/prep_beir_eval.py
@@ -27,8 +27,8 @@ def json_to_tsv(
 
                 text_list = []
                 for item in meta_list:
-                    if item == "text":
-                        content[item] = ' '.join(content[item].split()) # avoid '\t' and '\n' in text to impact file reader
+                    if item == "text" or item == "title":
+                        content[item] = ' '.join(content[item].split()) # avoid '\t' and '\n' in text and title to impact file reader
                     text_list.append(content[item])
                 fout.write('\t'.join(text_list) + '\n')
 


### PR DESCRIPTION
This PR aims to fix two bugs:
1.  The gpu_1_host trainer used in the msmarco baseline training set max_step 500.  @alexlimh pointed out it may cause error after training 500 steps. Maybe we should set it to null?
2. As pointed out by @Freddavide in the #14, the root cause is that some titles in BEIR original dataset contains "\t" or "\n", which may cause error in the transformed format. So we want to remove "\t" or "\n" in the title. 